### PR TITLE
fix: simplify Html component

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,7 +11,7 @@ module.exports = {
         },
       },
     ],
-    '@babel/preset-react',
+    ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-typescript',
   ],
 }

--- a/packages/r3f-perf/src/html.tsx
+++ b/packages/r3f-perf/src/html.tsx
@@ -1,5 +1,5 @@
 import { useThree } from '@react-three/fiber'
-import { forwardRef, ReactNode, useLayoutEffect, useRef } from 'react'
+import React, { forwardRef, ReactNode, useLayoutEffect, useRef } from 'react'
 import { createRoot, Root } from 'react-dom/client'
 
 interface HtmlProps {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     // use Node's module resolution algorithm, instead of the legacy TS one
     "moduleResolution": "node",
     // transpile JSX to React.createElement
-    "jsx": "react",
+    "jsx": "react-jsx",
     // interop between ESM and CJS modules. Recommended by TS
     "esModuleInterop": true,
     // significant perf increase by skipping checking .d.ts files, particularly those in node_modules. Recommended by TS
@@ -30,6 +30,6 @@
     // error out if import and file system have a casing mismatch. Recommended by TS
     "forceConsistentCasingInFileNames": true,
     // `tsdx build` ignores this option, but it is commonly used when type-checking separately with `tsc`
-    "noEmit": true,
+    "noEmit": true
   }
 }


### PR DESCRIPTION
**What**
- Enable jsx runtime
- Simplify logic in `<Html>` (remove babel generated code + move React root creation inside effect)

Everything seems to work the exact same way in the example app, not sure if there are more things to test