### PR TITLE
fix warning and use named function for easy debug

### DIFF
--- a/demo/src/sandboxes/perf-minimal/src/instances.jsx
+++ b/demo/src/sandboxes/perf-minimal/src/instances.jsx
@@ -29,7 +29,7 @@ export const Instances = ({row}) => {
   })
   return (
     <instancedMesh ref={ref} args={[null, null, row * row * row]} onPointerMove={e => setHover(e.instanceId)} onPointerOut={e => setHover(undefined)}>
-      <boxBufferGeometry attach="geometry" args={[0.7, 0.7, 0.7]} />
+      <boxGeometry attach="geometry" args={[0.7, 0.7, 0.7]} />
       <meshNormalMaterial attach="material" />
     </instancedMesh>
   )

--- a/example/instances.js
+++ b/example/instances.js
@@ -29,7 +29,7 @@ export const Instances = ({row}) => {
   })
   return (
     <instancedMesh ref={ref} args={[null, null, row * row * row]} onPointerMove={e => setHover(e.instanceId)} onPointerOut={e => setHover(undefined)}>
-      <boxBufferGeometry attach="geometry" args={[0.7, 0.7, 0.7]} />
+      <boxGeometry attach="geometry" args={[0.7, 0.7, 0.7]} />
       <meshNormalMaterial attach="material" />
     </instancedMesh>
   )

--- a/packages/r3f-perf/src/ui/graph.tsx
+++ b/packages/r3f-perf/src/ui/graph.tsx
@@ -320,7 +320,7 @@ export const ChartUI: FC<PerfUIProps> = ({
 
 const Renderer = () =>{
 
-  useFrame(({gl, scene, camera}) => {
+  useFrame(function updateR3fPerf ({gl, scene, camera}){
     camera.updateMatrix()
     matriceCount.value -= 1
     camera.matrixWorld.copy(camera.matrix)


### PR DESCRIPTION
![ano](https://user-images.githubusercontent.com/7174039/192215227-921dbbeb-f8f0-47dc-bbd5-493102b31621.PNG)

Make it easier to identify what part of the render is caused by r3f tool when debugging an app.
Also remove some warnings in latest THREE.js