### PR TITLE
fix: pin Zustand to brace against 4.3.x breaking changes

### DIFF
--- a/packages/r3f-perf/package.json
+++ b/packages/r3f-perf/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.0.3",
     "@stitches/react": "^1.2.8",
-    "zustand": "^4.1.5"
+    "zustand": "~4.2.0"
   },
   "devDependencies": {
     "@types/three": "latest"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10098,7 +10098,7 @@ __metadata:
     "@radix-ui/react-icons": ^1.0.3
     "@stitches/react": ^1.2.8
     "@types/three": latest
-    zustand: ^4.1.5
+    zustand: ~4.2.0
   peerDependencies:
     "@react-three/drei": "*"
     "@react-three/fiber": "*"
@@ -12740,9 +12740,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zustand@npm:^4.1.5":
-  version: 4.1.5
-  resolution: "zustand@npm:4.1.5"
+"zustand@npm:~4.2.0":
+  version: 4.2.0
+  resolution: "zustand@npm:4.2.0"
   dependencies:
     use-sync-external-store: 1.2.0
   peerDependencies:
@@ -12753,6 +12753,6 @@ __metadata:
       optional: true
     react:
       optional: true
-  checksum: 13190ee8e8a797c5347b525a7c392be62b2addacdd9645dd20d37ea053f96c7c7067c099c6201e98ebb8d54991f2e04e241cc323f9a25b841d44f0ae048e3afc
+  checksum: 70f9c9272c7ee6534d16e23e1f273822fdf4cb17a9865db588946ed250a51e169f8b0dcaf0a8d15e866239182263c015bca644756a69314ea1da4fe61ba1b67f
   languageName: node
   linkType: hard


### PR DESCRIPTION
Pins Zustand to `4.2.x` since `4.3.0` introduced a breaking change, removing the default export (https://github.com/pmndrs/zustand/pull/1514). Will need to investigate the effects of https://github.com/pmndrs/zustand/pull/1531 since it does not appear sufficient.