### PR TITLE
feat: name html group for easier debugging

### DIFF
--- a/src/components/HtmlMinimal.tsx
+++ b/src/components/HtmlMinimal.tsx
@@ -5,11 +5,12 @@ import { createRoot, Root } from 'react-dom/client'
 
 interface HtmlProps {
   portal?: React.MutableRefObject<HTMLElement>
-  className?: string
+  className?: string,
+  name?: string,
   children?: ReactNode
 }
 
-const HtmlMinimal = forwardRef<HTMLDivElement, HtmlProps>(({ portal, className, children, ...props }, ref) => {
+const HtmlMinimal = forwardRef<HTMLDivElement, HtmlProps>(({ portal, className, children, name, ...props }, ref) => {
   const gl = useThree(state => state.gl)
   const group = useRef(null)
   const rootRef = useRef<Root | null>(null)
@@ -41,7 +42,7 @@ const HtmlMinimal = forwardRef<HTMLDivElement, HtmlProps>(({ portal, className, 
     )
   })
 
-  return <group {...props} ref={group} />
+  return <group name={name} {...props} ref={group} />
 })
 
 export { HtmlMinimal }

--- a/src/components/Perf.tsx
+++ b/src/components/Perf.tsx
@@ -279,7 +279,7 @@ export const Perf: FC<PerfPropsGui> = ({
         deepAnalyze={deepAnalyze}
         matrixUpdate={matrixUpdate}
       />
-      <HtmlMinimal>
+      <HtmlMinimal name='r3f-perf'>
         <PerfS
           className={
             (className ? ' '.concat(className) : ' ') + ` ${position ? position : ''} ${minimal ? 'minimal' : ''}`


### PR DESCRIPTION
When debugging some scene, we might see the group generated by r3f-perf HTMLMinimal and wonder where it's coming from. adding name='r3f-perf' allows the developer to identify at first glance where this group is coming from. 