### PR TITLE
fix: shader count when deepAnalyze is true

### DIFF
--- a/src/components/TextsHighHZ.tsx
+++ b/src/components/TextsHighHZ.tsx
@@ -56,7 +56,7 @@ const TextHighHZ: FC<TextHighHZProps> = memo(
 
       let info = log[metric]
       if (isShadersInfo) {
-        info = gl.info.programs?.length
+        info = getPerf().programs.size
       } else if (metric === 'matriceCount') {
         info = matriceCount.value
       } else if (!isPerf && gl.info.render) {


### PR DESCRIPTION
Issue example: https://codesandbox.io/s/r3f-deep-analyze-issue-es4dpm?file=/src/App.js

This PR should make programs reporting more consistent when activating `deepAnalyze`.

I'm not entirely sure however this is a good approach since Three's `gl.info.programs` would still contain more programs than the one shown in r3f-perf, creating an inconsistency between the two reports.

