### PR TITLE
fix: cpuMeasure return null in ios

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -183,7 +183,8 @@ export class GLPerf {
         if (window.performance && this.startCpuProfiling) {
           window.performance.mark('cpu-finished')
           const cpuMeasure = performance.measure('cpu-duration', 'cpu-started', 'cpu-finished')
-          this.currentCpu = cpuMeasure.duration
+          // fix cpuMeasure return null in ios
+          this.currentCpu = cpuMeasure?.duration || 0;
 
           this.logsAccums.cpu.push(this.currentCpu)
           // make sure the measure has started and ended


### PR DESCRIPTION
cpuMeasure in ios return null