### PR TITLE
fix: camera rotation to prevent default_up

### DIFF
--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -155,6 +155,7 @@ export const ChartUI: FC<PerfUIProps> = ({
       <Canvas
         ref={canvas}
         orthographic
+        camera={{ rotation: [0, 0, 0] }}
         dpr={antialias ? [1,2] : 1}
         gl={{
           antialias: true,


### PR DESCRIPTION
Fixes a case when using a different `THREE.Object3D.DEFAULT_UP` that renders rotated orthographic projection:

![CleanShot 2024-03-30 at 02 14 28@2x](https://github.com/utsuboco/r3f-perf/assets/236249/0bfa82f5-455f-4bd5-841c-5ae3b0aa03a2)
