### PR TITLE
fix: bundled type declarations

### DIFF
--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -6,7 +6,7 @@ import { Canvas, useFrame, Viewport } from '@react-three/fiber';
 import { getPerf, usePerf } from '..';
 import { colorsGraph } from './Perf';
 import * as THREE from 'three';
-import { PerfUIProps } from '../typings';
+import type { PerfUIProps } from '../types';
 import { TextsHighHZ } from './TextsHighHZ';
 
 export interface graphData {

--- a/src/components/Graph.tsx
+++ b/src/components/Graph.tsx
@@ -1,9 +1,9 @@
-import { FC, useMemo, useRef } from 'react';
+import { type FC, useMemo, useRef } from 'react';
 import { matriceCount, matriceWorldCount } from './PerfHeadless';
 import { Graph, Graphpc } from '../styles';
 import { PauseIcon } from '@radix-ui/react-icons';
-import { Canvas, useFrame, Viewport } from '@react-three/fiber';
-import { getPerf, usePerf } from '..';
+import { Canvas, useFrame, type Viewport } from '@react-three/fiber';
+import { getPerf, usePerf } from '../store';
 import { colorsGraph } from './Perf';
 import * as THREE from 'three';
 import type { PerfUIProps } from '../types';
@@ -36,7 +36,7 @@ const ChartCurve:FC<PerfUIProps> = ({colorBlind, minimal, chart= {length: 120, h
   const updatePoints = (element: string, factor: number = 1, ref: any, viewport: Viewport) => {
     let maxVal = 0;
     const {width: w, height: h} = viewport
-    
+
     const chart = getPerf().chart.data[element];
     if (!chart || chart.length === 0) {
       return
@@ -51,17 +51,17 @@ const ChartCurve:FC<PerfUIProps> = ({colorBlind, minimal, chart= {length: 120, h
           maxVal = chart[id] * factor;
         }
         dummyVec3.set(padding + i / (len - 1) * (w - padding * 2) - w / 2, (Math.min(100, chart[id]) * factor) / 100 * (h - padding * 2 - paddingTop) - h / 2, 0)
-        
+
         dummyVec3.toArray(ref.attributes.position.array, i * 3)
       }
     }
-    
+
     ref.attributes.position.needsUpdate = true;
   };
 
   // const [supportMemory] = useState(window.performance.memory)
   useFrame(function updateChartCurve({viewport}) {
-    
+
     updatePoints('fps', 1, fpsRef.current, viewport)
     if (fpsMatRef.current) {
       fpsMatRef.current.color.set(getPerf().overclockingFps ? colorsGraph(colorBlind).overClock.toString() : `rgb(${colorsGraph(colorBlind).fps.toString()})`)
@@ -212,6 +212,6 @@ const Renderer = () =>{
     matriceCount.value = 0
   }, Infinity)
 
-  
+
   return null
 }

--- a/src/components/HtmlMinimal.tsx
+++ b/src/components/HtmlMinimal.tsx
@@ -1,5 +1,5 @@
 import { useThree } from '@react-three/fiber'
-import React, { forwardRef, ReactNode, useLayoutEffect, useRef } from 'react'
+import React, { forwardRef, type ReactNode, useLayoutEffect, useRef, useEffect } from 'react'
 // @ts-ignore
 import { createRoot, Root } from 'react-dom/client'
 

--- a/src/components/Perf.tsx
+++ b/src/components/Perf.tsx
@@ -23,7 +23,7 @@ import { PerfHeadless } from './PerfHeadless'
 import { Toggle, PerfS, PerfIContainer, PerfI, PerfB, ToggleContainer, ContainerScroll, PerfSmallI } from '../styles'
 import { ProgramsUI } from './Program'
 import { setPerf, usePerf } from '../store'
-import { PerfPropsGui } from '../typings'
+import type { PerfPropsGui } from '../types'
 
 interface colors {
   [index: string]: string

--- a/src/components/Perf.tsx
+++ b/src/components/Perf.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from 'react'
+import React, { type FC, useRef } from 'react'
 import { ChartUI } from './Graph'
 import {
   ActivityLogIcon,

--- a/src/components/PerfHeadless.tsx
+++ b/src/components/PerfHeadless.tsx
@@ -1,4 +1,4 @@
-import { FC, HTMLAttributes, useEffect, useMemo } from 'react'
+import { type FC, type HTMLAttributes, useEffect, useMemo } from 'react'
 import { addEffect, addAfterEffect, useThree, addTail } from '@react-three/fiber'
 import { overLimitFps, GLPerf } from '../internal'
 

--- a/src/components/PerfHeadless.tsx
+++ b/src/components/PerfHeadless.tsx
@@ -4,8 +4,8 @@ import { overLimitFps, GLPerf } from '../internal'
 
 import * as THREE from 'three'
 import { countGeoDrawCalls } from '../helpers/countGeoDrawCalls'
-import { getPerf, ProgramsPerfs, setPerf } from '../store'
-import { PerfProps } from '../typings'
+import { getPerf, type ProgramsPerfs, setPerf } from '../store'
+import type { PerfProps } from '../types'
 import { emitEvent } from '@utsubo/events'
 
 // cameras from r3f-perf scene

--- a/src/components/Program.tsx
+++ b/src/components/Program.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 
 import {
   ProgramGeo,
@@ -14,9 +14,8 @@ import {
   ProgramsGeoLi,
   ProgramsContainer,
 } from '../styles';
-import { usePerf } from '..';
 import { ActivityLogIcon, ButtonIcon, CubeIcon, EyeNoneIcon, EyeOpenIcon, ImageIcon, LayersIcon, RocketIcon, TriangleDownIcon, TriangleUpIcon, VercelLogoIcon } from '@radix-ui/react-icons';
-import type { ProgramsPerf } from '../store';
+import { usePerf, type ProgramsPerf } from '../store';
 import type { PerfProps } from '../types';
 import { estimateBytesUsed } from '../helpers/estimateBytesUsed';
 

--- a/src/components/Program.tsx
+++ b/src/components/Program.tsx
@@ -16,8 +16,8 @@ import {
 } from '../styles';
 import { usePerf } from '..';
 import { ActivityLogIcon, ButtonIcon, CubeIcon, EyeNoneIcon, EyeOpenIcon, ImageIcon, LayersIcon, RocketIcon, TriangleDownIcon, TriangleUpIcon, VercelLogoIcon } from '@radix-ui/react-icons';
-import { ProgramsPerf } from '../store';
-import { PerfProps } from '../typings';
+import type { ProgramsPerf } from '../store';
+import type { PerfProps } from '../types';
 import { estimateBytesUsed } from '../helpers/estimateBytesUsed';
 
 const addTextureUniforms = (id: string, texture: any) => {

--- a/src/components/TextsHighHZ.tsx
+++ b/src/components/TextsHighHZ.tsx
@@ -1,6 +1,6 @@
-import { FC, memo, Suspense, useRef } from 'react'
+import { type FC, memo, Suspense, useRef } from 'react'
 import { matriceCount, matriceWorldCount } from './PerfHeadless'
-import { useFrame, useThree } from '@react-three/fiber'
+import { useThree } from '@react-three/fiber'
 import { Text } from '@react-three/drei'
 import { getPerf } from '..'
 import { colorsGraph } from './Perf'

--- a/src/components/TextsHighHZ.tsx
+++ b/src/components/TextsHighHZ.tsx
@@ -5,7 +5,7 @@ import { Text } from '@react-three/drei'
 import { getPerf } from '..'
 import { colorsGraph } from './Perf'
 import * as THREE from 'three'
-import { customData, PerfUIProps } from '../typings'
+import type { customData, PerfUIProps } from '../types'
 import { useEvent } from '@utsubo/events'
 import localFont from '../roboto.woff'
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,6 @@
+declare module '*.woff';
+
+declare module '*.css' {
+  const content: { [className: string]: string }
+  export default content
+}

--- a/src/helpers/countGeoDrawCalls.ts
+++ b/src/helpers/countGeoDrawCalls.ts
@@ -1,4 +1,4 @@
-import { drawCounts, ProgramsPerfs } from '../store'
+import type { drawCounts, ProgramsPerfs } from '../store'
 
 export const countGeoDrawCalls = (programs: ProgramsPerfs) => {
   programs.forEach((program, _pkey) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -178,7 +178,7 @@ export const usePerfImpl = createWithEqualityFn<State>((set, get): any => {
   }
 })
 
-const usePerf = (sel: (state: State) => unknown) => usePerfImpl(sel, shallow)
+const usePerf = <S>(sel: (state: State) => S) => usePerfImpl(sel, shallow)
 Object.assign(usePerf, usePerfImpl)
 const { getState: getPerf, setState: setPerf } = usePerfImpl
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,4 @@
-declare module '*.css' {
-  const content: { [className: string]: string }
-  export default content
-}
+import type { HTMLAttributes } from 'react'
 
 export type chart = {
   length: number
@@ -34,7 +31,7 @@ export interface PerfPropsGui extends PerfProps {
   style?: object
 }
 
-interface PerfUIProps extends HTMLAttributes<HTMLDivElement> {
+export interface PerfUIProps extends HTMLAttributes<HTMLDivElement> {
   perfContainerRef?: any
   colorBlind?: boolean
   showGraph?: boolean

--- a/src/woff.d.ts
+++ b/src/woff.d.ts
@@ -1,1 +1,0 @@
-declare module '*.woff';


### PR DESCRIPTION
### `typings.d.ts` refactor (Fixes #56)

- Typescript completely skips `d.ts` files when emitting declarations, resulting in missing types from `typings.d.ts`.
- Utility/data types have been moved to `types.ts`, globals/module augmentations to `globals.d.ts`—publicly consumed types are now included in declaration emit, module augmentations are still skipped.
- A couple missing type import/exports have also been added.

Additional commit adds some type annotations to imports and refines `usePerf` signature