### PR TITLE
Fix Turbopack compatibility: use asset URL pattern for font

### DIFF
--- a/src/components/TextsHighHZ.tsx
+++ b/src/components/TextsHighHZ.tsx
@@ -7,7 +7,7 @@ import { colorsGraph } from './Perf'
 import * as THREE from 'three'
 import type { customData, PerfUIProps } from '../types'
 import { useEvent } from '@utsubo/events'
-import localFont from '../roboto.woff'
+import localFont from '../roboto-font'
 
 interface TextHighHZProps {
   metric?: string

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,5 +1,3 @@
-declare module '*.woff';
-
 declare module '*.css' {
   const content: { [className: string]: string }
   export default content

--- a/src/roboto-font.ts
+++ b/src/roboto-font.ts
@@ -1,0 +1,7 @@
+// Use standard asset URL pattern — consuming bundlers (Turbopack, webpack 5, Vite)
+// recognize `new URL('./file', import.meta.url)` and handle the asset automatically.
+// This avoids the original `import font from './roboto.woff'` which Turbopack
+// incorrectly tries to parse as UTF-8 JavaScript.
+// See: https://github.com/utsuboco/r3f-perf/issues/59
+const fontUrl = new URL('./roboto.woff', import.meta.url).href
+export default fontUrl


### PR DESCRIPTION
## Problem

When using r3f-perf with Next.js + Turbopack, the build fails with:

```
Code generation for roboto.woff.mjs failed: invalid utf-8 sequence of 1 bytes from index 0
```

This happens because the original `import font from './roboto.woff'` causes Turbopack to try parsing the binary font file as UTF-8 JavaScript.

Relates to #59 and #66.

## Solution

Use the standard asset URL pattern that all modern bundlers recognize:

```typescript
// src/roboto-font.ts
const fontUrl = new URL('./roboto.woff', import.meta.url).href
export default fontUrl
```

This pattern works with Turbopack, webpack 5, and Vite — they resolve the `.woff` file, copy it to the output, and provide a proper URL at runtime.

## Changes

- **`src/roboto-font.ts`** (new) — exports font using `new URL()` pattern
- **`src/components/TextsHighHZ.tsx`** — imports from `../roboto-font` instead of `../roboto.woff`
- **`src/globals.d.ts`** — removed `declare module '*.woff'` (no longer needed since we're not importing `.woff` files directly)

**3 files changed, 8 insertions(+), 3 deletions(-)**

## Why this pattern?

troika-three-text (used by drei's `<Text>`) loads fonts via a web worker with an opaque origin. The `new URL()` pattern ensures the font is accessible via HTTP URL, which works in all environments including web workers.

## Test plan

- [x] `pnpm run build` succeeds
- [x] Verified in Next.js 16 + Turbopack — font renders correctly